### PR TITLE
Enable Synopsys Black Duck scanning

### DIFF
--- a/synopsys-blackduck.yml.bak
+++ b/synopsys-blackduck.yml.bak
@@ -1,0 +1,1 @@
+CONTENTS


### PR DESCRIPTION

SUMMARY
Enable Synopsys Black Duck scanning by adding a new workflow configuration.

