### PR TITLE
Black Duck: Upgrade nodemailer to version v6.7.0 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "morgan": "^1.9.1",
     "multer": "^1.4.2",
     "node-cron": "^2.0.3",
-    "nodemailer": "^4.7.0",
+    "nodemailer": "^v6.7.0",
     "numeral": "^2.0.6",
     "paypal-rest-sdk": "^1.6.9",
     "rand-token": "^0.4.0",


### PR DESCRIPTION

Pull request submitted by Synopsys Black Duck to upgrade nodemailer from version 4.7.0 to v6.7.0 in order to fix the known security vulnerabilities:

* CVE-2020-7769 - CRITICAL severity vulnerability violates policy 'RAPID No Critical Vulns': *This affects the package nodemailer before 6.4.16. Use of crafted recipient email addresses may result in arbitrary command flag injection in sendmail transport for sending mails.* Recommended to upgrade to version v6.7.0. Direct dependency. Fix in package file 'package.json'