### PR TITLE
Black Duck: Upgrade axios to version v0.24.0 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "ajv": "^6.10.2",
     "async": "^2.6.3",
-    "axios": "^0.19.0",
+    "axios": "^v0.24.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "cheerio": "^0.22.0",


### PR DESCRIPTION

Pull request submitted by Synopsys Black Duck to upgrade axios from version 0.19.0 to v0.24.0 in order to fix the known security vulnerabilities:

* CVE-2021-3749 - HIGH severity vulnerability violates policy 'RAPID No Critical Vulns': *axios is vulnerable to Inefficient Regular Expression Complexity* Recommended to upgrade to version v0.24.0. Direct dependency.Fix in package file 'package.json'