### PR TITLE
Synopsys: Automated PR: sanitize-html/1.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "paypal-rest-sdk": "^1.6.9",
     "rand-token": "^0.4.0",
     "rimraf": "^2.7.1",
-    "sanitize-html": "^1.20.1",
+    "sanitize-html": "^2.8.1",
     "sitemap": "^1.6.0",
     "strip-bom": "^3.0.0",
     "stripe": "^5.10.0",


### PR DESCRIPTION
Vulnerabilities associated with this PR: 
BDSA-2021-2892 : It was discovered that sanitize-html failed to correctly handle internationalized domain names (IDN)'s. An attacker could exploit this flaw in order to bypass whitelisting of hostnames or to trick a victim into being redirected to a malicious site using a crafted URL. 
BDSA-2021-2893 : It was discovered that sanitize-html failed to correctly handle hostnames set by the `allowedIframeHostnames` option when the `allowIframeRelativeUrls` is set to true.

 An attacker could exploit this flaw in order to bypass whitelisting of hostnames for the iframe element, or to trick a victim into being redirected to a malicious site using a crafted URL. 
BDSA-2022-2387 : sanitize-html is vulnerable to a regular expression denial-of-service (DoS) issue due to the presence of a flawed regular expression in the `naughtyHref()` function.

An attacker could abuse this issue by submitting a crafted input that, when processed, could result in the excessive consumption of resources which could then impact the speed at which requests are processed. 
